### PR TITLE
Fixes issue in regex that breaks base64 image viewing.

### DIFF
--- a/src/image-viewer.component.ts
+++ b/src/image-viewer.component.ts
@@ -225,7 +225,7 @@ export class ImageViewerComponent implements OnChanges, OnInit, AfterViewInit {
     }
 
     isURlImagem() {
-        return this.getImagemAtual().match(new RegExp(/(https|http|www\.)/g));
+        return this.getImagemAtual().match(new RegExp(/^(https|http|www\.)/g));
     }
 
     prepararTrocaImagem() {


### PR DESCRIPTION
Because the regex was not fixed to the beginning of the base64 string, a sufficiently large image in base64 would trigger the wrong behaviour (URL versus data:image) due to containing the chracters www, http, https. This change should pin the regex to the beginning of the string, and fix the issue.